### PR TITLE
Deprecate Background page block

### DIFF
--- a/app/Filament/Fabricator/PageBlocks/Design/Background.php
+++ b/app/Filament/Fabricator/PageBlocks/Design/Background.php
@@ -8,12 +8,16 @@ use Filament\Forms\Components\Hidden;
 use Filament\Forms\Components\Section;
 use Z3d0X\FilamentFabricator\PageBlocks\PageBlock;
 
+/**
+ * @deprecated Since v2.1.0, march 2025, Background Image is now a core module. This block has no effect anymore. This is will be automatically hidden from your page block list. To avoid any issue in the future, please remove this block from your page block list.
+ */
 class Background extends PageBlock
 {
     public static function getBlockSchema(): Block
     {
         return Block::make('design.background')
             ->icon('heroicon-o-photo')
+            ->hidden()
             ->label(__('Background Image'))
             ->schema([
                 Section::make(__('Background Image'))


### PR DESCRIPTION
Background Image functionality is now a core module since v2.1.0. The component is hidden from page block lists to prevent duplicates.